### PR TITLE
image linking absolute + url prefix #29

### DIFF
--- a/obsidianhtml/__init__.py
+++ b/obsidianhtml/__init__.py
@@ -157,8 +157,8 @@ def ConvertMarkdownPageToHtmlPage(page_path_str, pb, backlinkNode=None):
         shutil.copyfile(full_link_path, dst_path)
 
         # [11.2] Adjust image link in page to new dst folder (when the link is to a file in our root folder)
-        new_link = '![]('+urllib.parse.quote(rel_path.as_posix())+')'
-        safe_link = re.escape('![](/'+link+')')
+        new_link = '![]('+urllib.parse.quote(config['html_url_prefix']+'/'+rel_path.as_posix())+')'
+        safe_link = re.escape('![]('+link+')')
         md.page = re.sub(safe_link, new_link, md.page)
    
 


### PR DESCRIPTION
For #29 

Not sure why I used relative linking there, that makes it very error prone when opening a note directly vs when opening it in a tab.
The relative form is nice for the markdown output.

Changed it to absolute and added the url prefix in, this solves the issue for me.