### PR TITLE
Graph view: Disabled dragging the central node

### DIFF
--- a/obsidianhtml/src/graph_template.html
+++ b/obsidianhtml/src/graph_template.html
@@ -139,26 +139,26 @@ function run(uid, pinnedNode){
 
 
         function dragstarted(d) {
-                // if (d.id == pinnedNode){
-                //         return
-                // }
+                if (d.id == pinnedNode){
+                        return
+                }
                 if (!d3.event.active) simulation.alphaTarget(0.3).restart();         
                 d.fx = d.x;
                 d.fy = d.y;
         }
 
         function dragged(d) {
-                // if (d.id == pinnedNode){
-                //         return
-                // }                
+                if (d.id == pinnedNode){
+                        return
+                }                
                 d.fx = d3.event.x;
                 d.fy = d3.event.y;
         }
 
         function dragended(d) {
-                // if (d.id == pinnedNode){
-                //         return
-                // }
+                if (d.id == pinnedNode){
+                        return
+                }
                 if (!d3.event.active) simulation.alphaTarget(0);
                 d.fx = null;
                 d.fy = null;


### PR DESCRIPTION
basically a bugfix
the central (=red) node is set to be in the center of the group, dragging it is not possible, without this change it will jump around.