### PR TITLE
minor fixes for #60 (no replacement on content)

### DIFF
--- a/obsidianhtml/__init__.py
+++ b/obsidianhtml/__init__.py
@@ -204,7 +204,6 @@ def ConvertMarkdownPageToHtmlPage(page_path_str, pb, backlinkNode=None):
         new_link = '![]('+urllib.parse.quote(config['html_url_prefix']+'/'+rel_path.as_posix())+')'
         safe_link = "\!\[.*\]\("+re.escape(link)+"\)"
         md.page = re.sub(safe_link, new_link, md.page)
-   
 
     # [1] Restore codeblocks/-lines
     # ------------------------------------------------------------------

--- a/obsidianhtml/lib.py
+++ b/obsidianhtml/lib.py
@@ -97,7 +97,9 @@ def ExportStaticFiles(pb):
     # Custom copy
     c = OpenIncludedFile('not_created.html')
     with open (pb.paths['html_output_folder'].joinpath('not_created.html'), 'w', encoding="utf-8") as f:
-        f.write(PopulateTemplate(pb, pb.html_template, content=c, dynamic_includes=''))
+        html = PopulateTemplate(pb, pb.html_template, content=c, dynamic_includes='')
+        html = html.replace('{html_url_prefix}', pb.config['html_url_prefix'])
+        f.write(html)
 
 def PopulateTemplate(pb, template, content, title='', dynamic_includes=None):
     # Defaults
@@ -109,6 +111,10 @@ def PopulateTemplate(pb, template, content, title='', dynamic_includes=None):
     return template\
         .replace('{title}', title)\
         .replace('{dynamic_includes}', pb.dynamic_inclusions)\
-        .replace('{content}', content)\
-        .replace('{html_url_prefix}', pb.config['html_url_prefix'])
+        .replace('{html_url_prefix}', pb.config['html_url_prefix'])\
+        .replace('{content}', content)
+
+        # Adding value replacement in content should be done in ConvertMarkdownPageToHtmlPage, 
+        # Between the md.StripCodeSections() and md.RestoreCodeSections() statements, otherwise codeblocks can be altered.
+        
     


### PR DESCRIPTION
Value replacement in note content should be done in ConvertMarkdownPageToHtmlPage between the md.StripCodeSections() and md.RestoreCodeSections() statements, otherwise codeblocks can be altered, which should never happen.