### PR TITLE
Add Nix flakes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/*
 **/geckodriver.log
 /obsidianhtml/src/installer/dist/**
 /obsidianhtml/src/html/css/master.css
+result

--- a/flake.lock
+++ b/flake.lock
@@ -33,14 +33,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663259453,
-        "narHash": "sha256-sVA0Rer4L46i1tLj+PR7UXGywjySM8KeNH1ORXMCgXc=",
-        "path": "/nix/store/z4f58l15qisyj9dabg6ykyw9mwkxd626-source",
-        "type": "path"
+        "lastModified": 1663491030,
+        "narHash": "sha256-MVsfBhE9US5DvLtBAaTRjwYdv1tLO8xjahM8qLXTgTo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "767542707d394ff15ac1981e903e005ba69528b5",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -15,22 +15,6 @@
         "type": "github"
       }
     },
-    "md-mermaid-repo": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645912413,
-        "narHash": "sha256-ZVIG5mD155zH9KEUmPNED91AgyXjdN7zUd+ZPI20zf4=",
-        "owner": "obsidian-html",
-        "repo": "md_mermaid",
-        "rev": "22c4d600da25397205471706abc9011e142d5f53",
-        "type": "github"
-      },
-      "original": {
-        "owner": "obsidian-html",
-        "repo": "md_mermaid",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1663491030,
@@ -50,7 +34,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "md-mermaid-repo": "md-mermaid-repo",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,56 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "md-mermaid-repo": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645912413,
+        "narHash": "sha256-ZVIG5mD155zH9KEUmPNED91AgyXjdN7zUd+ZPI20zf4=",
+        "owner": "obsidian-html",
+        "repo": "md_mermaid",
+        "rev": "22c4d600da25397205471706abc9011e142d5f53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "obsidian-html",
+        "repo": "md_mermaid",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663259453,
+        "narHash": "sha256-sVA0Rer4L46i1tLj+PR7UXGywjySM8KeNH1ORXMCgXc=",
+        "path": "/nix/store/z4f58l15qisyj9dabg6ykyw9mwkxd626-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "md-mermaid-repo": "md-mermaid-repo",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,119 @@
+{
+  description = "obsidian-html builder";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+  };
+  inputs.md-mermaid-repo = {
+    url = "github:obsidian-html/md_mermaid";
+    flake = false;
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    md-mermaid-repo,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        # temporary until upstream updates the PyPI package
+        mdMermaid = pkgs.python3.pkgs.buildPythonPackage {
+          name = "obsidianhtml-md-mermaid-fork";
+
+          patchPhase = ''
+            sed -i 's/md_mermaid/obsidianhtml-md-mermaid-fork/g' setup.py
+          '';
+
+          propagatedBuildInputs = with pkgs.python3Packages; [
+            markdown
+          ];
+
+          src = md-mermaid-repo;
+        };
+
+        makeYaml = config: let
+          configFile = pkgs.writeText "config.yml" (builtins.toJSON config);
+        in
+          pkgs.runCommandNoCC "config.yml" {} ''
+            (${pkgs.yj}/bin/yj -jy < ${configFile}) > $out
+          '';
+
+        setup = builtins.fromJSON (builtins.readFile (pkgs.runCommandNoCC "setup.cfg" {} ''
+          cat ${./setup.cfg} | ${pkgs.python3Packages.jc}/bin/jc --ini > $out
+        ''));
+
+        depNames = pkgs.lib.remove "obsidianhtml-md-mermaid-fork" (pkgs.lib.remove "" (pkgs.lib.splitString "\n"
+          setup
+          .options
+          .install_requires));
+
+        deps = [mdMermaid] ++ pkgs.lib.attrsets.attrVals depNames pkgs.python3Packages;
+      in rec {
+        packages.default = pkgs.python3.pkgs.buildPythonApplication rec {
+          pname = setup.metadata.name;
+          version = setup.metadata.version;
+          format = "pyproject";
+
+          checkPhase = ''
+            export PATH="$PATH:$out/bin"
+            ${pkgs.python3}/bin/python3 ci/tests/basic_regression_test.py
+          '';
+
+          src = ./.;
+
+          propagatedBuildInputs = deps;
+        };
+
+        checks.default = packages.default;
+
+        devShells.default = let
+          myPython = pkgs.python3.withPackages (p: [mdMermaid] ++ (pkgs.lib.attrsets.attrVals depNames p));
+        in
+          pkgs.mkShell {
+            buildInputs = [
+              myPython
+            ];
+            shellHook = ''
+              PYTHONPATH=${myPython}/${myPython.sitePackages}
+            '';
+          };
+
+        mkProject = args: let
+          config =
+            {
+              obsidian_folder_path_str = args.src;
+              obsidian_entrypoint_path_str = "${args.src}/${args.entrypoint}";
+              md_folder_path_str = "mdout";
+              md_entrypoint_path_str = "mdout/${args.entrypoint}";
+              html_output_folder_path_str = "htmlout";
+              copy_vault_to_tempdir = false;
+              site_name = args.name;
+            }
+            // (removeAttrs args ["obsidian_folder_path_str" "entrypoint" "src" "name" "md_folder_path_str" "md_entrypoint_path_str" "html_output_folder_path_str"]);
+          yamlConfig = makeYaml config;
+        in {
+          compile = pkgs.runCommandNoCC args.name {outputs = ["out" "md"];} ''
+            ln -s $out htmlout
+            ln -s $md mdout
+            ${packages.default}/bin/obsidianhtml convert -i ${yamlConfig}
+          '';
+          run = pkgs.writeShellApplication {
+            name = "run";
+            text = ''
+              TEMP=$(mktemp -d)
+              cd "$TEMP"
+              ${packages.default}/bin/obsidianhtml run -i ${yamlConfig}
+            '';
+          };
+        };
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = packages.default;
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,9 @@
     url = "github:obsidian-html/md_mermaid";
     flake = false;
   };
+  inputs.nixpkgs = {
+    url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
 
   outputs = {
     self,


### PR DESCRIPTION
This PR makes the project compatible with [Nix](https://nixos.org/), both for packaging, and for workflows. Users would be able to run `nix run github:obsidian-html/obsidian-html` to immediately use the project without relying on their system Python installation/packages and using fixed versions of all dependencies for a 100% reproducible environment across users. It also allows the tool to be easily used in Nix projects/workflows:

```nix
{
  description = "obsidianhtml example workflow";
  inputs.flake-utils = {
    url = "github:numtide/flake-utils";
  };
  inputs.obsidianhtml = {
    url = "github:obsidian-html/obsidian-html";
  };

  outputs = {
    self,
    nixpkgs,
    flake-utils,
    obsidianhtml,
  }:
    flake-utils.lib.eachDefaultSystem (
      system: let
        pkgs = import nixpkgs {
          inherit system;
        };

        name = "example";

        project = obsidianhtml.mkProject."${system}" {
          inherit name;
          src = ./content;
          entrypoint = "index.md";
        };
      in rec {
        packages.default = project.compile;

        devShells.default = pkgs.mkShell {
          inherit name;
          buildInputs = [
            obsidianhtml.packages."${system}".default
          ];
        };

        apps.run = flake-utils.lib.mkApp {
          drv = project.run;
        };
      }
    );
}
```

This is particularly useful with [install-nix-action](https://github.com/cachix/install-nix-action) which creates a reproducible build environment for CI/CD while being more lightweight than a virtualized solution like Docker. It can also be used to replace the testing pipeline in this repo, but I didn't want to make this PR too big.

Ideally, in the future the package itself can be upstreamed into [nixpkgs](https://github.com/NixOS/nixpkgs) and this repo would only need to handle the workflow aspects, but that's somewhat blocked by md-mermaid not getting its updates pushed to PyPI

This cannot be merged until #414 which is why it is a draft right now.