### PR TITLE
Allow inline code inclusion

### DIFF
--- a/obsidianhtml/MarkdownPage.py
+++ b/obsidianhtml/MarkdownPage.py
@@ -346,7 +346,7 @@ class MarkdownPage:
             self.page = re.sub(safe_str, new_md_str, self.page)
             
         # -- [10] Add code inclusions
-        for l in re.findall(r'^(\<inclusion href="[^"]*" />)', self.page, re.MULTILINE):
+        for l in re.findall(r'(\<inclusion href="[^"]*" />)', self.page, re.MULTILINE):
             link = l.replace('<inclusion href="', '').replace('" />', '')
             
             result = GetObsidianFilePath(link, self.file_tree, self.pb)
@@ -391,7 +391,7 @@ class MarkdownPage:
                 # Wrap up
                 included_page.RestoreCodeSections()
             
-            self.page = self.page.replace(l, included_page.page + '\n')
+            self.page = self.page.replace(l, '\n' + included_page.page + '\n')
 
 
         # -- [#296] Remove block references 


### PR DESCRIPTION
If an embed is used without a newline, the regex in ``MarkdownPage.py`` is unable to find it and retains it in the output HTML. This code removes the newline requirement and always adds a newline before the embed content so that if a header is present, it doesn't get added to a preexisting line