### PR TITLE
fix master.css bug and slight refactor

### DIFF
--- a/obsidianhtml/HeaderTree.py
+++ b/obsidianhtml/HeaderTree.py
@@ -38,9 +38,6 @@ def GetSubHeaderTree(header_tree, header_selector):
         if header_selector.count('#') == 0:
             header_element = header_selector
             new_header_selector = ''
-
-            print('header_element: ', header_element)
-
         else:
             header_element, new_header_selector = header_selector.split('#', 1)
 


### PR DESCRIPTION
The copy function expects a path relative to the site package, so exporting the master.css file to the destination did not work.

I noticed that the inbetween write/read was not necessary, as we already had the contents at hand - we just need to process it in the copy function loop so that we can reuse templating code, so I just made it a 'pseudo-file' where the contents are already in the file record itself.

