### PR TITLE
Add support for Strict Line Breaks mode.

### DIFF
--- a/obsidianhtml/MarkdownPage.py
+++ b/obsidianhtml/MarkdownPage.py
@@ -333,7 +333,8 @@ class MarkdownPage:
 
 
         # -- [7] Fix newline issue by adding three spaces before any newline
-        self.page = self.page.replace("\n", "   \n")
+        if not self.pb.config.config['toggles']['strict_line_breaks']:
+            self.page = self.page.replace("\n", "   \n")
 
         # -- [8] Insert markdown links for bare http(s) links (those without the [name](link) format).
         # Cannot start with [, (, nor "

--- a/obsidianhtml/src/defaults_config.yml
+++ b/obsidianhtml/src/defaults_config.yml
@@ -113,6 +113,10 @@ toggles:
   # Opt-in/-out of Md->Html conversion, set to False when only wanting to get proper markdown from Obsidian
   compile_html: True
 
+  # For compatibility with vaults/notes that have the 'Strict Line Breaks' option enabled
+  # This is off by default in Obsidian; setting it to True will not insert <br> tags into multi-line paragraphs
+  strict_line_breaks: False
+
   # gitlab is case insensitive, this setting should be true when converting a wiki from that source
   # might also be useful if you have markdown links in your vault
   # note that this does not impact the output, Hello.md will be written to Hello.html


### PR DESCRIPTION
Adds a new toggle in the configuration, defaulted to False, which suppresses the creation of newlines within paragraphs if set to True. This increases support for notes and vaults that have been created with Obsidian's "Strict Line Breaks" option.