### PR TITLE
Use html_url_prefix in favicon url

### DIFF
--- a/obsidianhtml/src/html/layouts/template_documentation.html
+++ b/obsidianhtml/src/html/layouts/template_documentation.html
@@ -7,7 +7,7 @@
                 <meta charset="UTF-8" />
                 <meta name="node_id" content="{node_id}">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <link rel="shortcut icon" href="/favicon.ico" />
+                <link rel="shortcut icon" href="{html_url_prefix}/favicon.ico" />
 
                 <!-- Set title -->
                 <title>{title}</title>

--- a/obsidianhtml/src/html/layouts/template_minimal.html
+++ b/obsidianhtml/src/html/layouts/template_minimal.html
@@ -6,7 +6,7 @@
         <meta charset="UTF-8" />
         <meta name="node_id" content="About ObsidianHtml">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="shortcut icon" href="{html_url_prefix}/favicon.ico" />
         <!-- Set title -->
         <title>{title}</title>
 

--- a/obsidianhtml/src/html/layouts/template_tabs.html
+++ b/obsidianhtml/src/html/layouts/template_tabs.html
@@ -7,7 +7,7 @@
                 <meta charset="UTF-8" />
                 <meta name="node_id" content="{node_id}">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-                <link rel="shortcut icon" href="/favicon.ico" />
+                <link rel="shortcut icon" href="{html_url_prefix}/favicon.ico" />
 
                 <!-- Set title -->
                 <title>{title}</title>


### PR DESCRIPTION
Hi :wave: Thanks for this project.

I found that the path to the favicon file was not using the `html_url_prefix` setting which makes the favicon 404 when this setting is not empty.