### PR TITLE
Removing versioning from Nix dependency handling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,10 +29,10 @@
           cat ${./setup.cfg} | ${pkgs.python3Packages.jc}/bin/jc --ini > $out
         ''));
 
-        depNames = pkgs.lib.remove "" (pkgs.lib.splitString "\n"
+        depNames = map (x: builtins.head(pkgs.lib.strings.splitString " " x)) (pkgs.lib.remove "" (pkgs.lib.splitString "\n"
           setup
           .options
-          .install_requires);
+          .install_requires));
 
         deps = pkgs.lib.attrsets.attrVals depNames pkgs.python3Packages;
       in rec {
@@ -100,3 +100,4 @@
       }
     );
 }
+


### PR DESCRIPTION
The version of the markdown dependency was specified in https://github.com/obsidian-html/obsidian-html/commit/aedf4eb214ddb9df17d70783c1ec9a5bead84fa2 which broke the Nix build. Since you can't easily specify Python package versions without using external libraries, I'm just ignoring them. If we ever need to bump the versions, we can just bump our version of `nixpkgs`