### PR TITLE
Suggested fix for #741

### DIFF
--- a/obsidianhtml/parser/MarkdownPage.py
+++ b/obsidianhtml/parser/MarkdownPage.py
@@ -122,12 +122,12 @@ class MarkdownPage:
 
     def RestoreCodeSections(self):
         """Undo the action of StripCodeSections."""
-        for i, value in enumerate(self.codeblocks):
-            self.page = self.page.replace(f"%%%codeblock-placeholder-{i}%%%", f"```{value}```\n")
-        for i, value in enumerate(self.codelines):
-            self.page = self.page.replace(f"%%%codeline-placeholder-{i}%%%", f"`{value}`")
         for i, value in enumerate(self.latexblocks):
             self.page = self.page.replace(f"%%%latexblock-placeholder-{i}%%%", f"$${value}$$")
+        for i, value in enumerate(self.codelines):
+            self.page = self.page.replace(f"%%%codeline-placeholder-{i}%%%", f"`{value}`")
+        for i, value in enumerate(self.codeblocks):
+            self.page = self.page.replace(f"%%%codeblock-placeholder-{i}%%%", f"```{value}```\n")
 
     def strip_svgs(self):
         self.svgs = []


### PR DESCRIPTION
This is one suggestion. As is the nature of the problem outlined in #741, this cannot be fully resolved without a major parsing rework. For details, see issue #741.

- linted with pylint `pylint obsidianhtml --errors-only --disable=E0602,E1126`
- linted with `pylint obsidianhtml --disable=E0602,E1126,R0401,R0801,R1702,C0201,C0301`
- checked with `ruff check obsidianhtml`
- checked with `black obsidianhtml`

(committed code not affected)