### PR TITLE
#475 Fix HOME in check phase

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
 
           checkPhase = ''
             export PATH="$PATH:$out/bin"
+            export HOME="$(mktemp -d)"
             ${pkgs.python3}/bin/python3 ci/tests/basic_regression_test.py
           '';
 


### PR DESCRIPTION
In Nix derivations, the `HOME` directory is automatically set to `/homeless-shelter` since builds are not allowed to touch user files. The workaround is just to create a temporary directory and set it to that.

Fixes #475.